### PR TITLE
RD-85 add two new stages

### DIFF
--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -34,23 +34,32 @@
       "name": "eggd_vcf_annotator_GNOMAD_GENOMES_AF",
       "executable": "applet-G70x6bQ433GyQFY6PJ4b37Z4",
       "input": {
-        "src_vcf_idx": {
-          "$dnanexus_link": "file-G6zvbFj4Kq47J4fY1pXGYgbK"
-        },
-        "ref_tar": {
-          "$dnanexus_link": "file-F3zxG0Q4fXX9YFjP1v5jK9jf"
-        },
         "dest_vcf": {
           "$dnanexus_link": {
             "stage": "stage-G72pJpj46jqgk1y3Kbb1KBxY",
             "outputField": "annotated_vcf"
           }
         },
-        "src_vcf": {
-          "$dnanexus_link": "file-G6zvbFj4Kq40Byxg1vkBq6fQ"
-        },
         "fields": "GNOMAD_GENOMES_AF:=AF",
-        "output_suffix": "GNOMAD_GENOMES_AF"
+        "output_suffix": "GNOMAD_GENOMES_AF",
+        "src_vcf": {
+          "$dnanexus_link": {
+            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+            "id": "file-G6zvbFj4Kq40Byxg1vkBq6fQ"
+          }
+        },
+        "src_vcf_idx": {
+          "$dnanexus_link": {
+            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+            "id": "file-G6zvbFj4Kq47J4fY1pXGYgbK"
+          }
+        },
+        "ref_tar": {
+          "$dnanexus_link": {
+            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+            "id": "file-F3zxG0Q4fXX9YFjP1v5jK9jf"
+          }
+        }
       }
     },
     {

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -1,29 +1,87 @@
 {
-  "name": "dias_reports_v1.3.3",
-  "title": "dias_reports_v1.3.3",
+  "name": "dias_reports_v1.4.0",
+  "title": "dias_reports_v1.4.0",
   "stages": [
     {
       "id": "stage-G72pJpj46jqgk1y3Kbb1KBxY",
+      "name": "eggd_vcf_annotator_TWE_AF",
       "executable": "applet-G70x6bQ433GyQFY6PJ4b37Z4",
       "input": {
-        "fields": "GNOMAD_AF:=AF",
-        "output_suffix": "gnomad_af",
+        "fields": "TWE_AF:=AF",
+        "output_suffix": "TWE_AF",
         "src_vcf": {
           "$dnanexus_link": {
-            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-            "id": "file-G6zvbFj4Kq40Byxg1vkBq6fQ"
-          }
-        },
-        "src_vcf_idx": {
-          "$dnanexus_link": {
-            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-            "id": "file-G6zvbFj4Kq47J4fY1pXGYgbK"
+            "project": "project-G7Y9zpj4kFXF78JjFgj70q3V",
+            "id": "file-G7xGgF84kFX13YqX8B2zvXY5"
           }
         },
         "ref_tar": {
           "$dnanexus_link": {
             "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
             "id": "file-F3zxG0Q4fXX9YFjP1v5jK9jf"
+          }
+        },
+        "src_vcf_idx": {
+          "$dnanexus_link": {
+            "project": "project-G7Y9zpj4kFXF78JjFgj70q3V",
+            "id": "file-G7xGgP04kFXP40Pb8Fk4819g"
+          }
+        }
+      }
+    },
+    {
+      "id": "stage-G80XFJj4k8jy6Gp05kk1kB07",
+      "name": "eggd_vcf_annotator_GNOMAD_GENOMES_AF",
+      "executable": "applet-G70x6bQ433GyQFY6PJ4b37Z4",
+      "input": {
+        "src_vcf_idx": {
+          "$dnanexus_link": "file-G6zvbFj4Kq47J4fY1pXGYgbK"
+        },
+        "ref_tar": {
+          "$dnanexus_link": "file-F3zxG0Q4fXX9YFjP1v5jK9jf"
+        },
+        "dest_vcf": {
+          "$dnanexus_link": {
+            "stage": "stage-G72pJpj46jqgk1y3Kbb1KBxY",
+            "outputField": "annotated_vcf"
+          }
+        },
+        "src_vcf": {
+          "$dnanexus_link": "file-G6zvbFj4Kq40Byxg1vkBq6fQ"
+        },
+        "fields": "GNOMAD_GENOMES_AF:=AF",
+        "output_suffix": "GNOMAD_GENOMES_AF"
+      }
+    },
+    {
+      "id": "stage-G80XZyj4k8jkV4GX9123j14g",
+      "name": "eggd_vcf_annotator_GNOMAD_EXOMES_AF",
+      "executable": "applet-G70x6bQ433GyQFY6PJ4b37Z4",
+      "input": {
+        "fields": "GNOMAD_EXOMES_AF:=AF",
+        "output_suffix": "GNOMAD_EXOMES_AF",
+        "src_vcf": {
+          "$dnanexus_link": {
+            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+            "id": "file-G7vj6504kFX7bQyx258v3f1z"
+          }
+        },
+        "src_vcf_idx": {
+          "$dnanexus_link": {
+            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+            "id": "file-G7vj6x04kFX53yZP1kF4x324"
+          }
+        },
+        "ref_tar": {
+          "$dnanexus_link": {
+            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+            "id": "file-F3zxG0Q4fXX9YFjP1v5jK9jf"
+          }
+        },
+        "dest_vcf": {
+          "$dnanexus_link": {
+            "stage": "stage-G80XFJj4k8jy6Gp05kk1kB07",
+            "outputField": "annotated_vcf"
           }
         }
       }
@@ -43,13 +101,13 @@
             "stage": "stage-G4BJkJQ4JxJvBv5vJq50vJZ8"
           }
         },
+        "annotations": "GNOMAD_AF",
         "annotated_vcf": {
           "$dnanexus_link": {
-            "stage": "stage-G72pJpj46jqgk1y3Kbb1KBxY",
+            "stage": "stage-G80XZyj4k8jkV4GX9123j14g",
             "outputField": "annotated_vcf"
           }
-        },
-        "annotations": "GNOMAD_AF"
+        }
       }
     },
     {

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -9,22 +9,22 @@
       "input": {
         "fields": "TWE_AF:=AF",
         "output_suffix": "TWE_AF",
-        "src_vcf": {
-          "$dnanexus_link": {
-            "project": "project-G7Y9zpj4kFXF78JjFgj70q3V",
-            "id": "file-G7xGgF84kFX13YqX8B2zvXY5"
-          }
-        },
         "ref_tar": {
           "$dnanexus_link": {
             "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
             "id": "file-F3zxG0Q4fXX9YFjP1v5jK9jf"
           }
         },
+        "src_vcf": {
+          "$dnanexus_link": {
+            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+            "id": "file-G7yVZj04kFX7XZFv1y0Jq2QG"
+          }
+        },
         "src_vcf_idx": {
           "$dnanexus_link": {
-            "project": "project-G7Y9zpj4kFXF78JjFgj70q3V",
-            "id": "file-G7xGgP04kFXP40Pb8Fk4819g"
+            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+            "id": "file-G7yVb804kFXP40Pb8Fk4z6x3"
           }
         }
       }


### PR DESCRIPTION
Two new stages added for gnomad genome & exome AFs. 
The old stage ids for gnomad AF is replaced by TWE AF to not cause major changes to the assay configs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_dias_reports_workflow/16)
<!-- Reviewable:end -->
