### PR TITLE
Di 366 v2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ DNAnexus workflow definition file of dias_reports for germline analysis.
 |eggd_vep      |1.1.0|
 |eggd_generate_variant_workbook    |2.5.0|
 |generate_bed       |1.2.0|
-|athena             |1.5.0|
+|athena             |1.4.0|
 
 ## What release of dias.py is required to run this workflow?
 

--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@ DNAnexus workflow definition file of dias_reports for germline analysis.
 
 -------
 
-## Current Version: 2.0.4
+## Current Version: 2.1.0
 
 ## What apps are used in this workflow?
 
 |  App 	| Version  	|
 |---	|---	|
-|eggd_vep      |1.0.0|
-|eggd_generate_variant_workbook    |2.0.3|
+|eggd_vep      |1.1.0|
+|eggd_generate_variant_workbook    |2.5.0|
 |generate_bed       |1.2.0|
-|athena             |1.4.0|
+|athena             |1.5.0|
 
 ## What release of dias.py is required to run this workflow?
 

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -42,7 +42,7 @@
     },
     {
       "id": "stage-rpt_athena",
-      "executable": "app-eggd_athena/1.5.0",
+      "executable": "app-eggd_athena/1.4.0",
       "input": {
         "panel_bed": {
           "$dnanexus_link": {

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -10,7 +10,7 @@
     },
     {
       "id": "stage-G9Q0jzQ4vyJ3x37X4KBKXZ5v",
-      "executable": "app-eggd_vep/1.0.0",
+      "executable": "app-eggd_vep/1.1.0",
       "input": {
         "panel_bed": {
           "$dnanexus_link": {

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -22,7 +22,7 @@
     },
     {
       "id": "stage-G9P8VQj4vyJBJ0kg50vzVPxY",
-      "executable": "app-eggd_generate_variant_workbook/2.0.3",
+      "executable": "app-eggd_generate_variant_workbook/2.5.0",
       "folder": "/workflow",
       "input": {
         "exclude_columns": "BaseQRankSum ClippingRankSum DB ExcessHet FS MLEAC MLEAF MQ MQRankSum QD ReadPosRankSum SOR PL QUAL ID FILTER  CSQ_ClinVar_CLNSIGCONF  CSQ_Allele CSQ_HGNC_ID DP AC AF AN CSQ_SpliceAI_pred_DP_AL CSQ_SpliceAI_pred_DP_AG CSQ_SpliceAI_pred_DP_DG CSQ_SpliceAI_pred_DP_DL",

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -22,7 +22,7 @@
     },
     {
       "id": "stage-rpt_generate_workbook",
-      "executable": "app-eggd_generate_variant_workbook/2.5.0",
+      "executable": "app-eggd_generate_variant_workbook/2.4.0",
       "folder": "/workflow",
       "input": {
         "vcfs": [

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -21,7 +21,7 @@
       }
     },
     {
-      "id": "stage-G9P8VQj4vyJBJ0kg50vzVPxY",
+      "id": "stage-rpt_generate_workbook",
       "executable": "app-eggd_generate_variant_workbook/2.5.0",
       "folder": "/workflow",
       "input": {

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -1,6 +1,6 @@
 {
-  "name": "dias_reports_v2.0.4",
-  "title": "dias_reports_v2.0.4",
+  "name": "dias_reports_v2.1.0",
+  "title": "dias_reports_v2.1.0",
   "stages": [
     {
       "id": "stage-rpt_generate_bed_vep",

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -22,7 +22,7 @@
     },
     {
       "id": "stage-rpt_generate_workbook",
-      "executable": "app-eggd_generate_variant_workbook/2.4.0",
+      "executable": "app-eggd_generate_variant_workbook/2.5.0",
       "folder": "/workflow",
       "input": {
         "vcfs": [

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -25,15 +25,6 @@
       "executable": "app-eggd_generate_variant_workbook/2.5.0",
       "folder": "/workflow",
       "input": {
-        "exclude_columns": "BaseQRankSum ClippingRankSum DB ExcessHet FS MLEAC MLEAF MQ MQRankSum QD ReadPosRankSum SOR PL QUAL ID FILTER  CSQ_ClinVar_CLNSIGCONF  CSQ_Allele CSQ_HGNC_ID DP AC AF AN CSQ_SpliceAI_pred_DP_AL CSQ_SpliceAI_pred_DP_AG CSQ_SpliceAI_pred_DP_DG CSQ_SpliceAI_pred_DP_DL",
-        "acmg": true,
-        "rename_columns": "CSQ_Feature=Transcript DP_FMT=DP",
-        "add_comment_column": true,
-        "keep_tmp": true,
-        "summary": "dias",
-        "filter": "bcftools filter -e '(CSQ_Consequence==\"synonymous_variant\" | CSQ_Consequence==\"intron_variant\" | CSQ_Consequence==\"upstream_gene_variant\" | CSQ_Consequence==\"downstream_gene_variant\" | CSQ_Consequence==\"intergenic_variant\" | CSQ_Consequence==\"5_prime_UTR_variant\" | CSQ_Consequence==\"3_prime_UTR_variant\" | CSQ_gnomADe_AF>0.01 | CSQ_gnomADg_AF>0.01 | CSQ_TWE_AF>0.05) & CSQ_HGMD_CLASS!~ \"DM\" & CSQ_ClinVar_CLNSIG!~ \"pathogenic\\/i\" & CSQ_ClinVar_CLNSIGCONF!~ \"pathogenic\\/i\"'",
-        "human_filter": "excluded gnomAD exomes / genomes > 1%, TWE > 5%, synonymous / intronic / intergenic / upstream / downstream / UTRs EXCEPT pathogenic status in ClinVar OR DM in HGMD Class",
-        "reorder_columns": "CHROM POS REF ALT GT GQ DP_FMT AD CSQ_SYMBOL CSQ_EXON CSQ_INTRON CSQ_HGVSc CSQ_HGVSp CSQ_Consequence CSQ_IMPACT CSQ_VARIANT_CLASS CSQ_gnomADe_AF CSQ_gnomADe_Hom CSQ_gnomADe_AC CSQ_gnomADe_AN CSQ_gnomADg_AF CSQ_gnomADg_AC CSQ_gnomADg_AN CSQ_TWE_AF CSQ_TWE_AC_Hom CSQ_TWE_AC_Het CSQ_TWE_AN CSQ_HGMD CSQ_HGMD_CLASS CSQ_HGMD_RANKSCORE CSQ_HGMD_PHEN CSQ_Existing_variation CSQ_ClinVar CSQ_ClinVar_CLNDN CSQ_ClinVar_CLNSIG CSQ_Mastermind_MMID3 CSQ_CADD_PHRED CSQ_REVEL CSQ_SpliceAI_pred_DS_AG CSQ_SpliceAI_pred_DS_AL CSQ_SpliceAI_pred_DS_DG CSQ_SpliceAI_pred_DS_DL CSQ_HGVS_OFFSET CSQ_STRAND CSQ_Feature",
         "vcfs": [
           {
             "$dnanexus_link": {

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -3,7 +3,7 @@
   "title": "dias_reports_v2.0.4",
   "stages": [
     {
-      "id": "stage-G9P8p104vyJJGy6y86FQBxkv",
+      "id": "stage-rpt_generate_bed_vep",
       "name": "generate_bed_for_vep",
       "executable": "app-generate_bed/1.2.0",
       "folder": "/workflow"
@@ -15,7 +15,7 @@
         "panel_bed": {
           "$dnanexus_link": {
             "outputField": "bed_file",
-            "stage": "stage-G9P8p104vyJJGy6y86FQBxkv"
+            "stage": "stage-rpt_generate_bed_vep"
           }
         }
       }

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -45,7 +45,7 @@
       }
     },
     {
-      "id": "stage-Fyq5yy0433GXxz691bKyvjPJ",
+      "id": "stage-rpt_generate_bed_athena",
       "name": "generate_bed_for_athena",
       "executable": "app-generate_bed/1.2.0"
     },
@@ -58,7 +58,7 @@
         "panel_bed": {
           "$dnanexus_link": {
             "outputField": "bed_file",
-            "stage": "stage-Fyq5yy0433GXxz691bKyvjPJ"
+            "stage": "stage-rpt_generate_bed_athena"
           }
         }
       }

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -50,7 +50,7 @@
       "executable": "app-generate_bed/1.2.0"
     },
     {
-      "id": "stage-Fyq5z18433GfYZbp3vX1KqjB",
+      "id": "stage-rpt_athena",
       "executable": "app-eggd_athena/1.5.0",
       "input": {
         "limit": 260,

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -44,8 +44,6 @@
       "id": "stage-rpt_athena",
       "executable": "app-eggd_athena/1.5.0",
       "input": {
-        "limit": 260,
-        "summary": true,
         "panel_bed": {
           "$dnanexus_link": {
             "outputField": "bed_file",

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -9,7 +9,7 @@
       "folder": "/workflow"
     },
     {
-      "id": "stage-G9Q0jzQ4vyJ3x37X4KBKXZ5v",
+      "id": "stage-rpt_vep",
       "executable": "app-eggd_vep/1.1.0",
       "input": {
         "panel_bed": {
@@ -38,7 +38,7 @@
           {
             "$dnanexus_link": {
               "outputField": "annotated_vcf",
-              "stage": "stage-G9Q0jzQ4vyJ3x37X4KBKXZ5v"
+              "stage": "stage-rpt_vep"
             }
           }
         ]

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -51,7 +51,7 @@
     },
     {
       "id": "stage-Fyq5z18433GfYZbp3vX1KqjB",
-      "executable": "app-eggd_athena/1.4.0",
+      "executable": "app-eggd_athena/1.5.0",
       "input": {
         "limit": 260,
         "summary": true,


### PR DESCRIPTION
Update written by @Jay-Miles 

**Changes**
- dxworkflow.json
  - Update name and title from v2.0.4 > v2.1.0
  - Update all apps to their most recent versions
    - eggd_vep: v1.0.0 > v1.1.0
    - eggd_generate_variant_workbook: v2.0.3 > v2.5.0
    - generate_bed: v1.2.0 > v1.2.0 (no change)
    - eggd_athena: v1.4.0 > v1.4.0 (no change) - v1.5.0 has been released, but is not updated here, because it has a bug which makes panel_filters a required input
  - Replace stage IDs with human-readable names
  - Remove static stage inputs, move into TWE and CEN configs
- readme.md
  -  Update current version from v2.0.4 > v2.1.0
  - Update app versions to reflect those in dxworkflow.json

**Testing**
Testing was done in the dnanexus project 003_230720_dias_reports_2.1.0_testing ([https://platform.dnanexus.com/projects/GXvQGY04QPQxjbz9zXVYF3xK/](https://platform.dnanexus.com/projects/GXvQGY04QPQxjbz9zXVYF3xK/)).
The DNAnexus workflow ID of the eggd_dias_cnvreports_workflow 1.1.0 workflow tested is `workflow-GXzkfYj4QPQp9z4Jz4BF09y6` ([link](https://platform.dnanexus.com/panx/projects/GXvQGY04QPQxjbz9zXVYF3xK/data/?id.constraint=%24or&id.values=workflow-GXzkfYj4QPQp9z4Jz4BF09y6J))
Tests were run to check that all the stages were remained and the apps versions were updated correctly, for both Epic and Gemini style manifests for both CEN and TWE dias runs.
![Screenshot from 2023-08-18 10-55-17](https://github.com/eastgenomics/eggd_dias_reports_workflow/assets/71272357/41b82253-adcc-4e58-9098-97aad3ddeb47)

Example screenshots used for testing:

Example job showing updated app versions, and renamed stage IDs
![Screenshot from 2023-08-18 10-43-49](https://github.com/eastgenomics/eggd_dias_reports_workflow/assets/71272357/f181a751-8481-4acc-9219-c1eeb6cb352d)
Example screenshot showing 13 test jobs; all stages completed successfully for all jobs
![Screenshot from 2023-08-18 10-40-59](https://github.com/eastgenomics/eggd_dias_reports_workflow/assets/71272357/72d6d15f-26c2-44cf-ab6e-4f1453c3297b)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_dias_reports_workflow/23)
<!-- Reviewable:end -->
