### PR TITLE
Remove generate bed steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ DNAnexus workflow definition file of dias_reports for germline analysis.
 
 -------
 
-## Current Version: 2.2.2
+## Current Version: 2.3.0
 
 ## What apps are used in this workflow?
 
@@ -12,7 +12,6 @@ DNAnexus workflow definition file of dias_reports for germline analysis.
 |eggd_vep      |1.3.0|
 |eggd_optimised_filtering      |1.1.0|
 |eggd_generate_variant_workbook    |2.8.2|
-|eggd_generate_bed       |1.3.0|
 |eggd_athena             |1.6.1|
 
 

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -1,24 +1,10 @@
 {
-  "name": "dias_reports_v2.2.2",
-  "title": "dias_reports_v2.2.2",
+  "name": "dias_reports_v2.3.0",
+  "title": "dias_reports_v2.3.0",
   "stages": [
     {
-      "id": "stage-rpt_generate_bed_vep",
-      "name": "generate_bed_for_vep",
-      "executable": "app-eggd_generate_bed/1.3.0",
-      "folder": "/workflow"
-    },
-    {
       "id": "stage-rpt_vep",
-      "executable": "app-eggd_vep/1.3.0",
-      "input": {
-        "panel_bed": {
-          "$dnanexus_link": {
-            "outputField": "bed_file",
-            "stage": "stage-rpt_generate_bed_vep"
-          }
-        }
-      }
+      "executable": "app-eggd_vep/1.3.0"
     },
     {
       "id": "stage-rpt_optimised_filtering",
@@ -50,21 +36,8 @@
       }
     },
     {
-      "id": "stage-rpt_generate_bed_athena",
-      "name": "generate_bed_for_athena",
-      "executable": "app-eggd_generate_bed/1.3.0"
-    },
-    {
       "id": "stage-rpt_athena",
-      "executable": "app-eggd_athena/1.6.1",
-      "input": {
-        "panel_bed": {
-          "$dnanexus_link": {
-            "outputField": "bed_file",
-            "stage": "stage-rpt_generate_bed_athena"
-          }
-        }
-      }
+      "executable": "app-eggd_athena/1.6.1"
     }
   ]
 }


### PR DESCRIPTION
The bed files will be the static ones in 001_Ref rather than generating them as part of this workflow

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_dias_reports_workflow/31)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated workflow version to 2.3.0, indicating new enhancements.
	- Simplified workflow structure by removing the `stage-rpt_generate_bed_vep` stage.

- **Bug Fixes**
	- Removed outdated application entry `eggd_generate_bed` from the workflow documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->